### PR TITLE
Reject host filenames CP/M can't represent in ValidCPMFilename

### DIFF
--- a/ntvcm.cxx
+++ b/ntvcm.cxx
@@ -363,6 +363,18 @@ bool ValidCPMFilename( char * pc )
     if ( pcdot && ( ( pcdot - pc ) > 8 ) )
         return false;
 
+    // CP/M extensions are at most 3 characters. Reject host names whose part
+    // after the dot is longer (e.g. ".gitignore"), or that contain a second
+    // dot, since CP/M can't represent them. Without this, such a file reaches
+    // ExtractFilename and trips its (extlen <= 3) assert during enumeration.
+    if ( pcdot )
+    {
+        if ( strchr( pcdot + 1, '.' ) )
+            return false;
+        if ( strlen( pcdot + 1 ) > 3 )
+            return false;
+    }
+
     return true;
 } //ValidCPMFilename
 


### PR DESCRIPTION
A name whose extension exceeds 3 characters (e.g. ".gitignore") or that contains a second dot has no valid CP/M representation. Previously such files passed ValidCPMFilename and later tripped the (extlen <= 3) assert in ExtractFilename during directory enumeration.

Reject these names up front: bail out if the part after the dot is longer than 3 chars or contains another dot for example .gitignore when running runall regression